### PR TITLE
fix: return absolute url directly in build_url instead of lstrip

### DIFF
--- a/src/yatl/request_builder.py
+++ b/src/yatl/request_builder.py
@@ -71,7 +71,7 @@ def build_url(base_url: str, url: str) -> str:
     if not base_url.startswith("http"):
         base_url = "https://" + base_url
     if url.startswith("http"):
-        url = url.lstrip("https://")
+        return url
     return base_url.rstrip("/") + "/" + url.lstrip("/")
 
 


### PR DESCRIPTION
Fixes #66

## Problem
`url.lstrip("https://")` strips individual characters, not the exact prefix. For example, `lstrip("https://")` would also strip leading `h`, `t`, `p`, `s`, `:`, `/` characters from the path.

## Fix
When `url` is already absolute (starts with `http`), return it directly instead of trying to strip the prefix.

```python
# Before
if url.startswith("http"):
    url = url.lstrip("https://")  # broken

# After  
if url.startswith("http"):
    return url  # correct
```