### PR TITLE
Fix: handle Timeout and ConnectionError in send_request

### DIFF
--- a/src/yatl/exceptions.py
+++ b/src/yatl/exceptions.py
@@ -1,0 +1,7 @@
+class YATLRequestError(Exception):
+    """Raised when an HTTP request fails due to a newtwork-level error.
+    
+    This is exception wraps lower-level transport errors (such as timeouts
+    and connection failures) into a single domain-specific exception, providing
+    a clear and user-friendly error message.
+    """

--- a/src/yatl/request_builder.py
+++ b/src/yatl/request_builder.py
@@ -23,9 +23,12 @@ def send_request(context: dict[str, Any], resolved_step: dict[str, Any]) -> Resp
         response = request(**request_data)
         return response
     except requests.exceptions.Timeout as e:
-        raise YATLRequestError(
-            f"Request timed out: {request_data['method']} {request_data['url']}"
-        ) from e
+        timeout_value = request_data.get("timeout")
+        if timeout_value is not None:
+           msg = f"Request timed out after {timeout_value}s: {request_data['method']} {request_data['url']}"
+        else:
+            msg = f"Request timed out (no explicit timeout set): {request_data['method']} {request_data['url']}"
+        raise YATLRequestError(msg) from e
     except requests.exceptions.ConnectionError as e:
         raise YATLRequestError(
             f"Connection failed: {request_data['method']} {request_data['url']}"

--- a/src/yatl/request_builder.py
+++ b/src/yatl/request_builder.py
@@ -1,6 +1,7 @@
+import requests
 from typing import Any
-
 from requests import Response, request
+from yatl.exceptions import YATLRequestError
 
 
 def send_request(context: dict[str, Any], resolved_step: dict[str, Any]) -> Response:
@@ -12,10 +13,24 @@ def send_request(context: dict[str, Any], resolved_step: dict[str, Any]) -> Resp
 
     Returns:
         The HTTP response object.
+
+    Raises:
+        YATLRequestError: If a network-level error occurs (timeout or
+            connection failure).
     """
     request_data = build_request_data(context, resolved_step)
-    response = request(**request_data)
-    return response
+    try:
+        response = request(**request_data)
+        return response
+    except requests.exceptions.Timeout as e:
+        raise YATLRequestError(
+            f"Request timed out: {request_data['method']} {request_data['url']}"
+        ) from e
+    except requests.exceptions.ConnectionError as e:
+        raise YATLRequestError(
+            f"Connection failed: {request_data['method']} {request_data['url']}"
+        ) from e
+
 
 
 def build_request_data(

--- a/tests/test_request_builder.py
+++ b/tests/test_request_builder.py
@@ -1,5 +1,12 @@
 from src.yatl.request_builder import build_url, extract_request_params, process_body
 
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from yatl.exceptions import YATLRequestError
+from src.yatl.request_builder import send_request
 
 def test_build_url():
     assert build_url("google.com", "") == "https://google.com/"
@@ -50,3 +57,42 @@ def test_process_body_xml():
     process_body(body, headers, kwargs)
     assert kwargs == {"data": "<user><name>John</name></user>"}
     assert headers == {"Content-Type": "application/xml"}
+
+
+
+CONTEXT = {"base_url": "https://api.example.com"}
+
+RESOLVED_STEP = {
+    "request": {
+        "method": "GET",
+        "url": "/users",
+    }
+}
+
+
+def test_send_request_raises_yatl_request_error_on_timeout():
+    "Test that send_request raises YATLRequestError on timeout."
+    with patch("src.yatl.request_builder.request") as mock_request:
+        mock_request.side_effect = requests.exceptions.Timeout()
+
+        with pytest.raises(YATLRequestError, match="Request timed out: GET"):
+            send_request(CONTEXT, RESOLVED_STEP)
+
+
+def test_send_request_raises_yatl_request_error_on_connection_error():
+    "Test that send_request raises YATLRequestError on connection error."
+    with patch("src.yatl.request_builder.request") as mock_request:
+        mock_request.side_effect = requests.exceptions.ConnectionError()
+
+        with pytest.raises(YATLRequestError, match="Connection failed: GET"):
+            send_request(CONTEXT, RESOLVED_STEP)
+
+
+def test_send_request_returns_response_on_success():
+    "Test that send_request returns the response object on success."
+    with patch("src.yatl.request_builder.request") as mock_request:
+        mock_request.return_value = "mock_response"
+
+        result = send_request(CONTEXT, RESOLVED_STEP)
+
+        assert result == "mock_response"

--- a/tests/test_request_builder.py
+++ b/tests/test_request_builder.py
@@ -69,14 +69,29 @@ RESOLVED_STEP = {
     }
 }
 
-
-def test_send_request_raises_yatl_request_error_on_timeout():
-    "Test that send_request raises YATLRequestError on timeout."
+def test_send_request_raises_yatl_request_error_on_timeout_without_value():
+    "Test that send_request raises YATLRequestError on timeout with no timeout set."
     with patch("src.yatl.request_builder.request") as mock_request:
         mock_request.side_effect = requests.exceptions.Timeout()
 
-        with pytest.raises(YATLRequestError, match="Request timed out: GET"):
+        with pytest.raises(YATLRequestError, match="Request timed out \\(no explicit timeout set\\): GET"):
             send_request(CONTEXT, RESOLVED_STEP)
+
+
+def test_send_request_raises_yatl_request_error_on_timeout_with_value():
+    "Test that send_request raises YATLRequestError on timeout with timeout value."
+    resolved_step_with_timeout = {
+        "request": {
+            "method": "GET",
+            "url": "/users",
+            "timeout": 30,
+        }
+    }
+    with patch("src.yatl.request_builder.request") as mock_request:
+        mock_request.side_effect = requests.exceptions.Timeout()
+
+        with pytest.raises(YATLRequestError, match="Request timed out after 30s: GET"):
+            send_request(CONTEXT, resolved_step_with_timeout)
 
 
 def test_send_request_raises_yatl_request_error_on_connection_error():


### PR DESCRIPTION
Closes #73

## Problem
`send_request` in `request_builder.py` did not handle network-level
exceptions. A timeout or unreachable server caused an unhandled
exception that crashed the program without giving the user any
meaningful information.

## Solution
- Added `YATLRequestError`, a domain-specific exception in the new
  `src/yatl/exceptions.py` module
- Wrapped the HTTP call in `send_request` with `try/except` blocks
  catching `requests.exceptions.Timeout` and
  `requests.exceptions.ConnectionError`
- Both exceptions are re-raised as `YATLRequestError` with a
  user-friendly message including the HTTP method and URL
- Original exceptions are chained using `raise ... from e` to
  preserve the full traceback for debugging

## Tests
Added 3 tests to `tests/test_request_builder.py`:
- `test_send_request_raises_yatl_request_error_on_timeout`
- `test_send_request_raises_yatl_request_error_on_connection_error`
- `test_send_request_returns_response_on_success`

All 36 tests pass.