### PR TITLE
fix(discovery): ignore empty test files

### DIFF
--- a/src/yatl/utils/file_utils.py
+++ b/src/yatl/utils/file_utils.py
@@ -51,6 +51,15 @@ def load_test_yaml(file_path: str) -> dict[str, str | int | list[Any]] | bool:
         raise InvalidYamlError(f"Encoding error in {file_path}: {e}")
 
 
+def _is_effectively_empty(file_path: str) -> bool:
+    """Return whether a YAML file contains only whitespace or comments."""
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            return all(not line.strip() or line.lstrip().startswith("#") for line in f)
+    except UnicodeDecodeError:
+        return False
+
+
 def search_files(base_path: str) -> list[str]:
     """Searches for test files with a .yatl.yaml/.yatl.yml suffix.
 
@@ -67,7 +76,9 @@ def search_files(base_path: str) -> list[str]:
         DirectoryNotFoundError: If base_path is neither a file nor a directory.
     """
     if os.path.isfile(base_path):
-        if base_path.endswith(".yatl.yaml") or base_path.endswith(".yatl.yml"):
+        if (
+            base_path.endswith(".yatl.yaml") or base_path.endswith(".yatl.yml")
+        ) and not _is_effectively_empty(base_path):
             return [base_path]
         return []
 
@@ -79,8 +90,10 @@ def search_files(base_path: str) -> list[str]:
     def _search(current_path: str):
         for item in os.listdir(current_path):
             full_path = os.path.join(current_path, item)
-            if os.path.isfile(full_path) and (
-                item.endswith(".yatl.yaml") or item.endswith(".yatl.yml")
+            if (
+                os.path.isfile(full_path)
+                and (item.endswith(".yatl.yaml") or item.endswith(".yatl.yml"))
+                and not _is_effectively_empty(full_path)
             ):
                 files.append(full_path)
             elif os.path.isdir(full_path):

--- a/tests/test_cli/test_command.py
+++ b/tests/test_cli/test_command.py
@@ -83,3 +83,19 @@ def test_skip(fixture_path):
     assert result.returncode == 0, (
         f"yatl exited with code {result.returncode}\nstdout: {result.stdout}\n"
     )
+
+
+def test_empty_test_files_are_ignored(tmp_path):
+    empty_test = tmp_path / "empty.yatl.yaml"
+    empty_test.write_text("", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "yatl", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "No .yatl.yaml files found" in result.stdout
+    assert "Run test:" not in result.stdout
+    assert "Test passed" not in result.stdout

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -49,6 +49,16 @@ def test_search_files():
     assert len(files) == 2
 
 
+@pytest.mark.parametrize("content", ["", "  \n\t", "# comment\n  # another comment\n"])
+def test_search_files_ignores_empty_yaml_files(tmp_path, content):
+    "Test that empty YAML files are excluded from test discovery."
+    empty_test = tmp_path / "empty.yatl.yaml"
+    empty_test.write_text(content, encoding="utf-8")
+
+    assert search_files(str(tmp_path)) == []
+    assert search_files(str(empty_test)) == []
+
+
 def test_search_files_with_invalid_path():
     "Test that search_files raises a clear error with invalid path."
     with pytest.raises(


### PR DESCRIPTION
## Summary

- ignore `.yatl.yaml` and `.yatl.yml` files that contain only whitespace or comments during discovery
- prevent empty test files from being counted or reported as passing
- cover directory discovery, direct file discovery, and CLI output

## Why

Empty test files were included in the discovered file count and then executed as empty test specifications. Filtering them during discovery keeps the reported count and output aligned with the tests that actually contain content.

Fixes #95

## Validation

- `pytest tests/test_run.py tests/test_cli/test_command.py::test_empty_test_files_are_ignored -q` (`12 passed`)
- `pytest --ignore=tests/test_cli/test_command.py -q` (`68 passed`)
- `ruff check .`
- `ruff format --check .`
